### PR TITLE
Missed-city-renaming

### DIFF
--- a/Natak/Natak.Core/Models/BoardResponse.cs
+++ b/Natak/Natak.Core/Models/BoardResponse.cs
@@ -15,8 +15,8 @@ public sealed class BoardResponse
     [JsonPropertyName("villages")]
     public required List<BuildingResponse> Villages { get; init; }
 
-    [JsonPropertyName("cities")]
-    public required List<BuildingResponse> Cities { get; init; }
+    [JsonPropertyName("towns")]
+    public required List<BuildingResponse> Towns { get; init; }
 
     [JsonPropertyName("ports")]
     public required List<PortResponse> Ports { get; init; }
@@ -28,7 +28,7 @@ public sealed class BoardResponse
             Hexes = [],
             Roads = board.GetRoads().Select(RoadResponse.FromDomain).ToList(),
             Villages = [],
-            Cities = [],
+            Towns = [],
             Ports = board.GetPorts().Select(PortResponse.FromDomain).ToList()
         };
 
@@ -59,7 +59,7 @@ public sealed class BoardResponse
                     }
                     else if (house.Type == BuildingType.Town)
                     {
-                        boardStatusResponse.Cities.Add(BuildingResponse.FromDomain(house, point));
+                        boardStatusResponse.Towns.Add(BuildingResponse.FromDomain(house, point));
                     }
                 }
             }

--- a/Natak/Natak.Core/Models/DetailedPlayerResponse.cs
+++ b/Natak/Natak.Core/Models/DetailedPlayerResponse.cs
@@ -43,7 +43,7 @@ public sealed class DetailedPlayerResponse : PlayerResponse
             TotalGrowthCards = baseResponse.TotalGrowthCards,
             HasLargestArmy = baseResponse.HasLargestArmy,
             HasLongestRoad = baseResponse.HasLongestRoad,
-            RemainingCities = baseResponse.RemainingCities,
+            RemainingTowns = baseResponse.RemainingTowns,
             RemainingRoads = baseResponse.RemainingRoads,
             RemainingVillages = baseResponse.RemainingVillages,
             CardsToDiscard = baseResponse.CardsToDiscard

--- a/Natak/Natak.Core/Models/PlayerResponse.cs
+++ b/Natak/Natak.Core/Models/PlayerResponse.cs
@@ -29,8 +29,8 @@ public class PlayerResponse
     [JsonPropertyName("remainingVillages")]
     public required int RemainingVillages { get; init; }
 
-    [JsonPropertyName("remainingCities")]
-    public required int RemainingCities { get; init; }
+    [JsonPropertyName("remainingTowns")]
+    public required int RemainingTowns { get; init; }
 
     [JsonPropertyName("remainingRoads")]
     public required int RemainingRoads { get; init; }
@@ -54,7 +54,7 @@ public class PlayerResponse
             HasLargestArmy = player.ScoreManager.HasLargestArmy,
             HasLongestRoad = player.ScoreManager.HasLongestRoad,
             RemainingVillages = player.PieceManager.Villages,
-            RemainingCities = player.PieceManager.Cities,
+            RemainingTowns = player.PieceManager.Towns,
             RemainingRoads = player.PieceManager.Roads,
             CardsToDiscard = player.CardsToDiscard
         };

--- a/Natak/Natak.Domain/Board.cs
+++ b/Natak/Natak.Domain/Board.cs
@@ -219,7 +219,7 @@ public sealed class Board
 
     public Result CanMoveThiefToPoint(Point point)
     {
-        if (!TilePointIsValid(point) || point.Equals(ThiefPosition))
+        if (!TilePointIsValid(point))
         {
             return Result.Failure(BoardErrors.InvalidTilePoint);
         }
@@ -486,7 +486,7 @@ public sealed class Board
     {
         if (!TilePointIsValid(point))
         {
-            throw new ArgumentException("Point are not valid.");
+            throw new ArgumentException("Point is not valid.");
         }
 
         var surroundingHouses = GetHousesOnTile(point);

--- a/Natak/Natak.Domain/Errors/BoardErrors.cs
+++ b/Natak/Natak.Domain/Errors/BoardErrors.cs
@@ -37,7 +37,7 @@ public static class BoardErrors
     public static Error RoadDoesNotConnect => new(
         HttpStatusCode.BadRequest,
         "Board.RoadDoesNotConnect",
-        "Road does not connect to any existing roads, villages or cities.");
+        "Road does not connect to any existing roads, villages or towns.");
 
     public static Error InvalidVillagePoint => new(
         HttpStatusCode.BadRequest,

--- a/Natak/Natak.Domain/Factories/GameFactory.cs
+++ b/Natak/Natak.Domain/Factories/GameFactory.cs
@@ -144,9 +144,9 @@ internal static class GameFactory
 
             var existingRoads = player.PieceManager.Roads;
             var existingVillages = player.PieceManager.Villages;
-            var existingCities = player.PieceManager.Cities;
+            var existingTowns = player.PieceManager.Towns;
 
-            piecesLeftToRemove = existingRoads + existingVillages + existingCities > 0;
+            piecesLeftToRemove = existingRoads + existingVillages + existingTowns > 0;
         }
         while (piecesLeftToRemove);
     }

--- a/Natak/Natak.Domain/Game.cs
+++ b/Natak/Natak.Domain/Game.cs
@@ -465,7 +465,7 @@ public sealed class Game
         return Result.Success();
     }
 
-    public Result StealResourceFromPlayer(PlayerColour player)
+    public Result StealResourceFromPlayer(PlayerColour playerColour)
     {
         var moveStateResult = MoveState(ActionType.StealResource);
 
@@ -474,7 +474,15 @@ public sealed class Game
             return moveStateResult;
         }
 
-        return PlayerManager.StealFromPlayer(CurrentPlayerColour, player);
+        var thiefPosition = Board.ThiefPosition;
+        var playerColoursToStealFrom = Board.GetHouseColoursOnTile(thiefPosition);
+
+        if (!playerColoursToStealFrom.Contains(playerColour))
+        {
+            return Result.Failure(GameErrors.PlayerToStealFromDoesNotHaveHouseOnTile);
+        }
+
+        return PlayerManager.StealFromPlayer(CurrentPlayerColour, playerColour);
     }
 
     public Result TradeWithBank(

--- a/Natak/Natak.Domain/Game.cs
+++ b/Natak/Natak.Domain/Game.cs
@@ -518,43 +518,6 @@ public sealed class Game
         return Result.Success();
     }
 
-    private Result PlaceRoamingRoads(
-        Point firstRoadFirstPoint,
-        Point firstRoadSecondPoint,
-        Point secondRoadFirstPoint,
-        Point secondRoadSecondPoint)
-    {
-        var firstRoadResult = PlaceRoamingRoad(firstRoadFirstPoint, firstRoadSecondPoint);
-
-        if (firstRoadResult.IsFailure)
-        {
-            return firstRoadResult;
-        }
-
-        return PlaceRoamingRoad(secondRoadFirstPoint, secondRoadSecondPoint);
-    }
-
-    private Result PlaceRoamingRoad(
-        Point firstPoint,
-        Point secondPoint)
-    {
-        var playerPieceResult = CurrentPlayer.RemovePiece(BuildingType.Road);
-
-        if (playerPieceResult.IsFailure)
-        {
-            return playerPieceResult;
-        }
-
-        var placeResult = Board.PlaceRoad(firstPoint, secondPoint, CurrentPlayerColour, IsSetup);
-
-        if (placeResult.IsFailure)
-        {
-            return placeResult;
-        }
-
-        return Result.Success();
-    }
-
     private void DistributeResourcesOnTilePoint(Point tilePoint)
     {
         if (tilePoint.Equals(Board.ThiefPosition))

--- a/Natak/Natak.Domain/Managers/PlayerPieceManager.cs
+++ b/Natak/Natak.Domain/Managers/PlayerPieceManager.cs
@@ -8,5 +8,5 @@ public sealed class PlayerPieceManager : ItemManager<BuildingType>
 
     public int Villages => items[BuildingType.Village];
 
-    public int Cities => items[BuildingType.Town];
+    public int Towns => items[BuildingType.Town];
 }

--- a/Natak/test/Natak.Domain.UnitTests/BoardTests.cs
+++ b/Natak/test/Natak.Domain.UnitTests/BoardTests.cs
@@ -82,7 +82,7 @@ public sealed class BoardTests
     }
 
     [Fact]
-    public void CreateBoard_EmptyVillagesAndCitiesAreNull()
+    public void CreateBoard_EmptyVillagesAndTownsAreNull()
     {
         // Act
         var board = new Board();

--- a/Natak/test/Natak.Domain.UnitTests/GameTests.cs
+++ b/Natak/test/Natak.Domain.UnitTests/GameTests.cs
@@ -57,15 +57,15 @@ public sealed class GameTests
         };
         var game = GameFactory.Create(gameOptions);
         var availableLocations = game.GetAvailableTownLocations().Value;
-        var existingCities = game.CurrentPlayer.PieceManager.Cities;
+        var existingTowns = game.CurrentPlayer.PieceManager.Towns;
 
         // Act
         var result = game.PlaceTown(availableLocations.First());
 
         // Assert
-        var newCities = game.CurrentPlayer.PieceManager.Cities;
+        var newTowns = game.CurrentPlayer.PieceManager.Towns;
         Assert.True(result.IsSuccess);
-        Assert.Equal(existingCities - 1, newCities);
+        Assert.Equal(existingTowns - 1, newTowns);
     }
 
     [Fact]


### PR DESCRIPTION
'Cities' renamed to 'Towns'.
Fix bug allowing current player to steal from players who don't have a house on the thief tile.