### PR TITLE
Fix roaming card breaking when player has one or zero road pieces

### DIFF
--- a/Natak/Natak.Domain/Game.cs
+++ b/Natak/Natak.Domain/Game.cs
@@ -384,7 +384,14 @@ public sealed class Game
         }
 
         GrowthCardPlayed = true;
-        roamingRoadsLeftToPlace = MAX_ROAD_BUILDING_ROADS;
+
+        var playerRemainingRoads = PlayerManager.CurrentPlayer.PieceManager.Roads;
+        
+        roamingRoadsLeftToPlace = Math.Min(
+            playerRemainingRoads,
+            MAX_ROAD_BUILDING_ROADS);
+        
+        CheckFinishedRoaming();
 
         return Result.Success();
     }

--- a/Natak/test/Natak.Domain.UnitTests/GameTests.cs
+++ b/Natak/test/Natak.Domain.UnitTests/GameTests.cs
@@ -911,6 +911,48 @@ public sealed class GameTests
     }
 
     [Fact]
+    public void PlayRoamingCard_Should_NotFinishInRoamingState_WhenPlayerHasNoRoadPieces()
+    {
+        //Arrange
+        var gameOptions = new GameFactoryOptions
+        {
+            IsSetup = false,
+            GivePlayersGrowthCards = true,
+            RemovePlayersPieces = true
+        };
+        var game = GameFactory.Create(gameOptions);
+        
+        //Act
+        var result = game.PlayRoamingCard();
+        
+        //Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotEqual(GameState.Roaming, game.CurrentState);
+    }
+
+    [Fact]
+    public void PlayRoamingCard_Should_OnlyRequireOneRoadPlacement_WhenPlayerOnlyHasOneRoadPiece()
+    {
+        //Arrange
+        var gameOptions = new GameFactoryOptions
+        {
+            IsSetup = false,
+            GivePlayersGrowthCards = true,
+            RemovePlayersPieces = true
+        };
+        var game = GameFactory.Create(gameOptions);
+        game.CurrentPlayer.PieceManager.Add(BuildingType.Road);
+        
+        //Act
+        var result = game.PlayRoamingCard();
+        
+        //Assert
+        Assert.True(result.IsSuccess);
+        var remainingRoadsToPlace = game.GetRoamingRoadsLeftToPlace();
+        Assert.Equal(1, remainingRoadsToPlace);
+    }
+
+    [Fact]
     public void PlayRoamingCard_Should_ReturnFailure_WhenPlayerHasAlreadyPlayedGrowthCard()
     {
         // Arrange


### PR DESCRIPTION
Now allows use of roaming card if player has one or zero remaining road pieces. If the player has one, only that one needs to be placed. If the player has none, the game continues as normal. The growth card is used up in both cases.