### PR TITLE
Fix growth cards able to be purchased before rolling

### DIFF
--- a/Natak/Natak.Core/Mappers/ActionTypeResponseMapper.cs
+++ b/Natak/Natak.Core/Mappers/ActionTypeResponseMapper.cs
@@ -22,7 +22,8 @@ public static class ActionTypeResponseMapper
         { ActionType.RollSeven, ActionTypeResponse.RollDice },
         { ActionType.AllResourcesDiscarded, ActionTypeResponse.DiscardResources },
         { ActionType.MoveThief, ActionTypeResponse.MoveThief },
-        { ActionType.StealResource, ActionTypeResponse.StealResource }
+        { ActionType.StealResource, ActionTypeResponse.StealResource },
+        { ActionType.BuyGrowthCard, ActionTypeResponse.BuyGrowthCard }
     };
 
     public static ActionTypeResponse? FromDomain(ActionType actionType)

--- a/Natak/Natak.Core/Models/ActionTypeResponse.cs
+++ b/Natak/Natak.Core/Models/ActionTypeResponse.cs
@@ -11,5 +11,6 @@ public enum ActionTypeResponse
     PlayGrowthCard,
     DiscardResources,
     MoveThief,
-    StealResource
+    StealResource,
+    BuyGrowthCard
 }

--- a/Natak/Natak.Domain/Enums/ActionType.cs
+++ b/Natak/Natak.Domain/Enums/ActionType.cs
@@ -19,5 +19,6 @@ public enum ActionType
     AllResourcesDiscarded,
     MoveThief,
     StealResource,
-    PlayerHasWon
+    PlayerHasWon,
+    BuyGrowthCard
 }

--- a/Natak/Natak.Domain/Game.cs
+++ b/Natak/Natak.Domain/Game.cs
@@ -206,6 +206,13 @@ public sealed class Game
 
     public Result BuyGrowthCard()
     {
+        var moveStateResult = MoveState(ActionType.BuyGrowthCard);
+        
+        if (moveStateResult.IsFailure)
+        {
+            return moveStateResult;
+        }
+        
         return PurchaseHelper.BuyGrowthCard(CurrentPlayer, BankManager);
     }
 

--- a/Natak/Natak.Domain/Managers/GameStateManager.cs
+++ b/Natak/Natak.Domain/Managers/GameStateManager.cs
@@ -20,6 +20,7 @@ public sealed class GameStateManager : StateManager
         { new(GameState.AfterRoll, ActionType.BuildVillage), new(GameState.AfterRoll) },
         { new(GameState.AfterRoll, ActionType.BuildRoad), new(GameState.AfterRoll) },
         { new(GameState.AfterRoll, ActionType.BuildTown), new(GameState.AfterRoll) },
+        { new(GameState.AfterRoll, ActionType.BuyGrowthCard), new(GameState.AfterRoll)},
         { new(GameState.AfterRoll, ActionType.Trade), new(GameState.AfterRoll) },
         { new(GameState.AfterRoll, ActionType.PlaySoldierCard), new(GameState.MoveThief, StateTransitionType.Add) },
         { new(GameState.AfterRoll, ActionType.PlayRoamingCard), new(GameState.Roaming, StateTransitionType.Add) },

--- a/Natak/Natak.Domain/Managers/PlayerManager.cs
+++ b/Natak/Natak.Domain/Managers/PlayerManager.cs
@@ -179,6 +179,10 @@ public sealed class PlayerManager
             {
                 player.CardsToDiscard = resourceCount / 2;
             }
+            else
+            {
+                player.CardsToDiscard = 0;
+            }
         }
     }
 

--- a/Natak/test/Natak.Domain.UnitTests/GameTests.cs
+++ b/Natak/test/Natak.Domain.UnitTests/GameTests.cs
@@ -417,6 +417,24 @@ public sealed class GameTests
         Assert.True(result.IsSuccess);
         Assert.NotEmpty(game.CurrentPlayer.Ports);
     }
+    
+    [Fact]
+    public void BuyGrowthCard_Should_ReturnFailure_WhenInIncorrectState()
+    {
+        // Arrange
+        var gameOptions = new GameFactoryOptions
+        {
+            IsSetup = false,
+            GivePlayersResources = true
+        };
+        var game = GameFactory.Create(gameOptions);
+
+        // Act
+        var result = game.BuyGrowthCard();
+
+        // Assert
+        Assert.True(result.IsFailure);
+    }
 
     [Fact]
     public void DiscardResources_Should_ReturnFailure_WhenPlayerDoesNotNeedToDiscard()


### PR DESCRIPTION
Added a new action type of 'BuyGrowthCard'. This allows us to check the game is in a correct state when attempting to buy a growth card.

Should fix the issue with players having fewer resource cards than they had to discard. For example, the player would roll a 7 while having 10 resource cards and so have to discard 5. They would then purchase two growth cards (costing 3 resources each) taking them down to 4 resource cards, and therefore be unable to discard 5 resource cards.