### PR TITLE
43-longest-road-calculation-not-checking-road-colour

### DIFF
--- a/Natak/Natak.Domain/Factories/GameFactory.cs
+++ b/Natak/Natak.Domain/Factories/GameFactory.cs
@@ -185,7 +185,8 @@ internal static class GameFactory
         var roadLocations = new List<(Point, Point)>
         {
             (new(2, 2), new(3, 2)),
-            (new(2, 3), new(1, 3))
+            (new(2, 3), new(1, 3)),
+            (new(1, 3), new(1, 4)),
         };
 
         foreach (var (firstPoint, secondPoint) in roadLocations)

--- a/Natak/Natak.Domain/Managers/BuildingManager.cs
+++ b/Natak/Natak.Domain/Managers/BuildingManager.cs
@@ -214,10 +214,7 @@ public sealed class BuildingManager
 
         var roadsOfColour = GetRoads(colour);
 
-        var endRoads = roadsOfColour.Where(r => GetRoadsOfColourAtPoint(r.FirstPoint, colour).Count == 1
-                                                || GetRoadsOfColourAtPoint(r.SecondPoint, colour).Count == 1).ToList();
-
-        var endPoints = endRoads
+        var endPoints = roadsOfColour
             .Select(r =>
                 GetRoadsOfColourAtPoint(r.FirstPoint, colour).Count == 1
                     ? r.FirstPoint

--- a/Natak/Natak.Domain/Managers/BuildingManager.cs
+++ b/Natak/Natak.Domain/Managers/BuildingManager.cs
@@ -214,12 +214,12 @@ public sealed class BuildingManager
 
         var roadsOfColour = GetRoads(colour);
 
-        var endRoads = roadsOfColour.Where(r => GetOccupiedRoadsAtPoint(r.FirstPoint).Count == 1
-                                                || GetOccupiedRoadsAtPoint(r.SecondPoint).Count == 1).ToList();
+        var endRoads = roadsOfColour.Where(r => GetRoadsOfColourAtPoint(r.FirstPoint, colour).Count == 1
+                                                || GetRoadsOfColourAtPoint(r.SecondPoint, colour).Count == 1).ToList();
 
         var endPoints = endRoads
             .Select(r =>
-                GetOccupiedRoadsAtPoint(r.FirstPoint).Count == 1
+                GetRoadsOfColourAtPoint(r.FirstPoint, colour).Count == 1
                     ? r.FirstPoint
                     : r.SecondPoint)
             .ToList();
@@ -330,7 +330,7 @@ public sealed class BuildingManager
             throw new ArgumentException($"{nameof(colour)} must not be {PlayerColour.None}.");
         }
 
-        var connectedRoads = GetOccupiedRoadsAtPoint(point);
+        var connectedRoads = GetRoadsOfColourAtPoint(point, colour);
 
         var connectedRoadsNotChecked = connectedRoads.Where(r => !checkedRoads.Contains(r)).ToList();
 

--- a/Natak/test/Natak.Domain.UnitTests/GameTests.cs
+++ b/Natak/test/Natak.Domain.UnitTests/GameTests.cs
@@ -257,7 +257,7 @@ public sealed class GameTests
     }
 
     [Fact]
-    public void PlaceRoad_Should_SetWinner_IfPlayerNeedsOnePoint_AndGetsLongestRoad()
+    public void PlaceRoad_Should_SetWinner_IfPlayerNeedsTwoPoints_AndGetsLongestRoad()
     {
         // Arrange
         var gameOptions = new GameFactoryOptions
@@ -272,7 +272,7 @@ public sealed class GameTests
         var game = GameFactory.Create(gameOptions);
 
         // Act
-        var result = game.PlaceRoad(new(1, 3), new(1, 4));
+        var result = game.PlaceRoad(new(1, 4), new(2, 4));
 
         // Assert
         Assert.True(result.IsSuccess);
@@ -766,14 +766,14 @@ public sealed class GameTests
     }
 
     [Fact]
-    public void PlaySoldierCard_Should_SetWinner_IfPlayerNeedsOnePoint_AndGetsLargestArmy()
+    public void PlaySoldierCard_Should_SetWinner_IfPlayerNeedsTwoPoints_AndGetsLargestArmy()
     {
         // Arrange
         var gameOptions = new GameFactoryOptions
         {
             IsSetup = false,
             GivePlayersGrowthCards = true,
-            PlayersVisiblePoints = 9,
+            PlayersVisiblePoints = 8,
             PlayersHiddenPoints = 0,
             PrepareLargestArmy = true
         };
@@ -1298,8 +1298,7 @@ public sealed class GameTests
         };
         var game = GameFactory.Create(gameOptions);
         var player = game.PlayerManager.Players
-            .Where(p => p.Colour != game.CurrentPlayerColour)
-            .First();
+            .First(p => p.Colour != game.CurrentPlayerColour);
 
         // Act
         var result = game.StealResourceFromPlayer(player.Colour);
@@ -1323,8 +1322,7 @@ public sealed class GameTests
         var playerColour = game.PlayerManager.Players
             .Select(p => p.Colour)
             .Except(coloursOnPoint)
-            .Where(c => c != game.CurrentPlayerColour)
-            .First();
+            .First(c => c != game.CurrentPlayerColour);
 
         game.MoveThief(point);
 
@@ -1363,9 +1361,9 @@ public sealed class GameTests
                     continue;
                 }
 
-                playerColourToStealFrom = game.Board.GetHouseColoursOnTile(point)
-                    .Where(c => c != currentPlayerColour)
-                    .FirstOrDefault();
+                playerColourToStealFrom = game.Board
+                    .GetHouseColoursOnTile(point)
+                    .FirstOrDefault(c => c != currentPlayerColour);
 
                 if (playerColourToStealFrom != null)
                 {

--- a/Natak/test/Natak.Domain.UnitTests/Managers/BuildingManagerTests.cs
+++ b/Natak/test/Natak.Domain.UnitTests/Managers/BuildingManagerTests.cs
@@ -658,4 +658,37 @@ public sealed class BuildingManagerTests
         // Assert
         Assert.Equal(3, length);
     }
+    
+    [Fact]
+    public void GetLengthOfLongestRoadForColour_DoesNotCountRoadsOfDifferentColour()
+    {
+        // Arrange
+        var buildingManager = new BuildingManager();
+        const PlayerColour playerColour = PlayerColour.Blue;
+        const PlayerColour otherPlayerColour = PlayerColour.Red;
+        var roads = new List<Road>
+        {
+            new(playerColour, new Point(2, 0), new Point(3, 0)),
+            new(playerColour, new Point(3, 0), new Point(4, 0)),
+            new(playerColour, new Point(5, 0), new Point(4, 0)),
+            new(playerColour, new Point(5, 0), new Point(6, 0)),
+            new(playerColour, new Point(6, 0), new Point(6, 1)),
+            new(otherPlayerColour, new Point(6, 1), new Point(7, 1)),
+            new(otherPlayerColour, new Point(7, 1), new Point(8, 1)),
+        };
+        var house = new House(playerColour, HouseType.Village, new Point(2, 0));
+
+        buildingManager.AddVillage(house);
+
+        foreach (var road in roads)
+        {
+            buildingManager.AddRoad(road);
+        }
+
+        // Act
+        var length = buildingManager.GetLengthOfLongestRoadForColour(playerColour);
+
+        // Assert
+        Assert.Equal(5, length);
+    }
 }

--- a/Natak/test/Natak.Domain.UnitTests/Managers/BuildingManagerTests.cs
+++ b/Natak/test/Natak.Domain.UnitTests/Managers/BuildingManagerTests.cs
@@ -691,4 +691,174 @@ public sealed class BuildingManagerTests
         // Assert
         Assert.Equal(5, length);
     }
+    
+    [Fact]
+    public void GetLengthOfLongestRoadForColour_ReturnsCorrectLengthForALoop()
+    {
+        // Arrange
+        var buildingManager = new BuildingManager();
+        const PlayerColour playerColour = PlayerColour.Blue;
+        var roads = new List<Road>
+        {
+            new(playerColour, new Point(2, 0), new Point(3, 0)),
+            new(playerColour, new Point(3, 0), new Point(4, 0)),
+            new(playerColour, new Point(4, 0), new Point(4, 1)),
+            new(playerColour, new Point(4, 1), new Point(3, 1)),
+            new(playerColour, new Point(3, 1), new Point(2, 1)),
+            new(playerColour, new Point(2, 1), new Point(2, 0))
+        };
+        var house = new House(playerColour, HouseType.Village, new Point(2, 0));
+
+        buildingManager.AddVillage(house);
+
+        foreach (var road in roads)
+        {
+            buildingManager.AddRoad(road);
+        }
+
+        // Act
+        var length = buildingManager.GetLengthOfLongestRoadForColour(playerColour);
+
+        // Assert
+        Assert.Equal(6, length);
+    }
+    
+    [Fact]
+    public void GetLengthOfLongestRoadForColour_ReturnsCorrectLengthForLoopAndSeparateShorterRoad()
+    {
+        // Arrange
+        var buildingManager = new BuildingManager();
+        const PlayerColour playerColour = PlayerColour.Blue;
+        var roads = new List<Road>
+        {
+            new(playerColour, new Point(2, 0), new Point(3, 0)),
+            new(playerColour, new Point(3, 0), new Point(4, 0)),
+            new(playerColour, new Point(4, 0), new Point(4, 1)),
+            new(playerColour, new Point(4, 1), new Point(3, 1)),
+            new(playerColour, new Point(3, 1), new Point(2, 1)),
+            new(playerColour, new Point(2, 1), new Point(2, 0)),
+            new(playerColour, new Point(5, 0), new Point(6, 0)),
+            new(playerColour, new Point(6, 0), new Point(7, 0)),
+            new(playerColour, new Point(7, 0), new Point(8, 0))
+        };
+        var firstHouse = new House(playerColour, HouseType.Village, new Point(2, 0));
+        var secondHouse = new House(playerColour, HouseType.Village, new Point(5, 0));
+
+        buildingManager.AddVillage(firstHouse);
+        buildingManager.AddVillage(secondHouse);
+
+        foreach (var road in roads)
+        {
+            buildingManager.AddRoad(road);
+        }
+
+        // Act
+        var length = buildingManager.GetLengthOfLongestRoadForColour(playerColour);
+
+        // Assert
+        Assert.Equal(6, length);
+    }
+    
+    [Fact]
+    public void GetLengthOfLongestRoadForColour_ReturnsCorrectLengthAndColourForComplexBoard()
+    {
+        // Arrange
+        var buildingManager = new BuildingManager();
+        var roads = new List<Road>
+        {
+            // Blue
+            new(PlayerColour.Blue, new Point(2, 4), new Point(2, 5)),
+            new(PlayerColour.Blue, new Point(2, 5), new Point(3, 5)),
+            new(PlayerColour.Blue, new Point(3, 5), new Point(4, 5)),
+            
+            new(PlayerColour.Blue, new Point(9, 1), new Point(9, 2)),
+            new(PlayerColour.Blue, new Point(9, 2), new Point(10, 2)),
+            new(PlayerColour.Blue, new Point(10, 2), new Point(10, 3)),
+            
+            // Red
+            new(PlayerColour.Red, new Point(6, 0), new Point(7, 0)),
+            new(PlayerColour.Red, new Point(7, 0), new Point(8, 0)),
+            new(PlayerColour.Red, new Point(8, 0), new Point(8, 1)),
+            new(PlayerColour.Red, new Point(8, 1), new Point(7, 1)),
+            new(PlayerColour.Red, new Point(8, 1), new Point(9, 1)),
+            
+            new(PlayerColour.Red, new Point(8, 5), new Point(8, 4)),
+            new(PlayerColour.Red, new Point(8, 4), new Point(9, 4)),
+            
+            // Green
+            new(PlayerColour.Green, new Point(2, 1), new Point(2, 0)),
+            new(PlayerColour.Green, new Point(2, 0), new Point(3, 0)),
+            new(PlayerColour.Green, new Point(3, 0), new Point(4, 0)),
+            new(PlayerColour.Green, new Point(4, 0), new Point(5, 0)),
+            new(PlayerColour.Green, new Point(4, 0), new Point(4, 1)),
+            new(PlayerColour.Green, new Point(4, 1), new Point(5, 1)),
+            
+            new(PlayerColour.Green, new Point(4, 4), new Point(4, 5)),
+            new(PlayerColour.Green, new Point(4, 5), new Point(5, 5)),
+            new(PlayerColour.Green, new Point(5, 5), new Point(6, 5)),
+            new(PlayerColour.Green, new Point(6, 5), new Point(7, 5)),
+            new(PlayerColour.Green, new Point(7, 5), new Point(8, 5)),
+            new(PlayerColour.Green, new Point(6, 5), new Point(6, 4)),
+            new(PlayerColour.Green, new Point(6, 4), new Point(5, 4)),
+            new(PlayerColour.Green, new Point(6, 4), new Point(7, 4)),
+            new(PlayerColour.Green, new Point(7, 4), new Point(8, 4)),
+            
+            // Yellow
+            new(PlayerColour.Yellow, new Point(1, 1), new Point(2, 1)),
+            new(PlayerColour.Yellow, new Point(2, 1), new Point(3, 1)),
+            new(PlayerColour.Yellow, new Point(3, 1), new Point(4, 1)),
+            new(PlayerColour.Yellow, new Point(3, 1), new Point(3, 2)),
+            new(PlayerColour.Yellow, new Point(3, 2), new Point(4, 2)),
+            new(PlayerColour.Yellow, new Point(4, 2), new Point(4, 3)),
+            new(PlayerColour.Yellow, new Point(4, 3), new Point(5, 3)),
+            new(PlayerColour.Yellow, new Point(5, 3), new Point(5, 4)),
+            
+            new(PlayerColour.Yellow, new Point(7, 1), new Point(7, 2)),
+            new(PlayerColour.Yellow, new Point(7, 2), new Point(8, 2)),
+            new(PlayerColour.Yellow, new Point(8, 2), new Point(9, 2)),
+            new(PlayerColour.Yellow, new Point(8, 2), new Point(8, 3)),
+            new(PlayerColour.Yellow, new Point(8, 3), new Point(9, 3)),
+            new(PlayerColour.Yellow, new Point(9, 3), new Point(10, 3)),
+            new(PlayerColour.Yellow, new Point(9, 3), new Point(9, 4))
+        };
+        
+        var houses = new List<House>
+        {
+            new(PlayerColour.Blue, HouseType.Village, new Point(2, 4)),
+            new(PlayerColour.Blue, HouseType.Village, new Point(3, 5)),
+            new(PlayerColour.Blue, HouseType.Village, new Point(10, 2)),
+            new(PlayerColour.Red, HouseType.Village, new Point(8, 1)),
+            new(PlayerColour.Red, HouseType.Town, new Point(8, 5)),
+            new(PlayerColour.Red, HouseType.Village, new Point(9, 4)),
+            new(PlayerColour.Green, HouseType.Town, new Point(2, 0)),
+            new(PlayerColour.Green, HouseType.Town, new Point(4, 4)),
+            new(PlayerColour.Green, HouseType.Town, new Point(6, 4)),
+            new(PlayerColour.Yellow, HouseType.Town, new Point(1, 1)),
+            new(PlayerColour.Yellow, HouseType.Town, new Point(4, 1)),
+            new(PlayerColour.Yellow, HouseType.Town, new Point(7, 2)),
+            new(PlayerColour.Yellow, HouseType.Town, new Point(8, 3))
+        };
+        
+        foreach (var house in houses)
+        {
+            buildingManager.AddVillage(house);
+        }
+
+        foreach (var road in roads)
+        {
+            buildingManager.AddRoad(road);
+        }
+
+        // Act
+        var blueLength = buildingManager.GetLengthOfLongestRoadForColour(PlayerColour.Blue);
+        var redLength = buildingManager.GetLengthOfLongestRoadForColour(PlayerColour.Red);
+        var greenLength = buildingManager.GetLengthOfLongestRoadForColour(PlayerColour.Green);
+        var yellowLength = buildingManager.GetLengthOfLongestRoadForColour(PlayerColour.Yellow);
+
+        // Assert
+        Assert.Equal(3, blueLength);
+        Assert.Equal(4, redLength);
+        Assert.Equal(6, greenLength);
+        Assert.Equal(7, yellowLength);
+    }
 }


### PR DESCRIPTION
The longest road calculation was including roads of any colour in the calculation, obviously causing incorrect results.
Additionally, loops without a clear end point could also cause errors, so the calculation now checks every point of every road. Less efficient, but correct.